### PR TITLE
AttributesSelectionManager: Support flag for skipping selection

### DIFF
--- a/lib/geet/shared/selection.rb
+++ b/lib/geet/shared/selection.rb
@@ -4,6 +4,8 @@ module Geet
   module Shared
     module Selection
       MANUAL_LIST_SELECTION_FLAG = '-'.freeze
+      # Don't select anything; return the null value.
+      SKIP_LIST_SELECTION_FLAG = ''.freeze
 
       SELECTION_SINGLE = :single
       SELECTION_MULTIPLE = :multiple

--- a/lib/geet/utils/attributes_selection_manager.rb
+++ b/lib/geet/utils/attributes_selection_manager.rb
@@ -79,6 +79,8 @@ module Geet
         case pattern
         when MANUAL_LIST_SELECTION_FLAG
           Geet::Utils::ManualListSelection.new.select_entry(entry_type, entries, name_method: name_method)
+        when SKIP_LIST_SELECTION_FLAG
+          nil
         else
           Geet::Utils::StringMatchingSelection.new.select_entry(entry_type, entries, pattern, name_method: name_method)
         end
@@ -99,6 +101,8 @@ module Geet
         case pattern
         when MANUAL_LIST_SELECTION_FLAG
           Geet::Utils::ManualListSelection.new.select_entries(entry_type, entries, name_method: name_method)
+        when SKIP_LIST_SELECTION_FLAG
+          []
         else
           Geet::Utils::StringMatchingSelection.new.select_entries(entry_type, entries, pattern, name_method: name_method)
         end

--- a/lib/geet/utils/attributes_selection_manager.rb
+++ b/lib/geet/utils/attributes_selection_manager.rb
@@ -76,7 +76,8 @@ module Geet
       #   select_entry('milestone', all_milestones, '0.1.0', :title)
       #
       def select_entry(entry_type, entries, pattern, name_method)
-        if pattern == MANUAL_LIST_SELECTION_FLAG
+        case pattern
+        when MANUAL_LIST_SELECTION_FLAG
           Geet::Utils::ManualListSelection.new.select_entry(entry_type, entries, name_method: name_method)
         else
           Geet::Utils::StringMatchingSelection.new.select_entry(entry_type, entries, pattern, name_method: name_method)
@@ -95,7 +96,8 @@ module Geet
         #
         pattern = pattern.join(',') if pattern.is_a?(Array)
 
-        if pattern == MANUAL_LIST_SELECTION_FLAG
+        case pattern
+        when MANUAL_LIST_SELECTION_FLAG
           Geet::Utils::ManualListSelection.new.select_entries(entry_type, entries, name_method: name_method)
         else
           Geet::Utils::StringMatchingSelection.new.select_entries(entry_type, entries, pattern, name_method: name_method)


### PR DESCRIPTION
Allow a given parameter (e.g. reviewer) not to be selected at all, skipping the selection menu. This is very convenient in certain cases.