### PR TITLE
Bump required Ruby version to 2.6

### DIFF
--- a/geet.gemspec
+++ b/geet.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |s|
   s.name        = 'geet'
   s.version     = Geet::VERSION
   s.platform    = Gem::Platform::RUBY
-  s.required_ruby_version = '>= 2.3.0'
+  s.required_ruby_version = '>= 2.6.0'
   s.authors     = ['Saverio Miroddi']
   s.date        = '2022-08-07'
   s.email       = ['saverio.pub2@gmail.com']


### PR DESCRIPTION
A 2.6 feature (unbounded ranges) was already used.