### PR TITLE
Create PR: Add retry on branch push failure

### DIFF
--- a/lib/geet/services/create_pr.rb
+++ b/lib/geet/services/create_pr.rb
@@ -123,7 +123,22 @@ module Geet
 
           @out.puts "Creating remote branch #{remote_branch.inspect}..."
 
-          @git_client.push(remote_branch: remote_branch)
+          begin
+            @git_client.push(remote_branch: remote_branch)
+          rescue
+            # A case where this helps is if a push hook fails.
+            #
+            @out.print "Error while pushing; retry (Y/N*)?"
+            input = $stdin.getch
+            @out.puts
+
+            case input.downcase.rstrip
+            when 'n', ''
+              # exit the cycle
+            else
+              retry
+            end
+          end
         end
       end
 


### PR DESCRIPTION
Useful, for example, if a hook blocks the push, so that the user can update the branch in the background.